### PR TITLE
Add specified-anchor syntax for multilingual, using `~~`

### DIFF
--- a/src/markdown/index.js
+++ b/src/markdown/index.js
@@ -21,12 +21,18 @@ md.use(mdItAnchor, {
 
 md.use((md, syntax) => {
   md.core.ruler.push('heading_comments', ({tokens}) => {
-    for (let token of tokens.filter(token => token.type === 'heading_open')) {
-      const title = tokens[tokens.indexOf(token) + 1].children[0];
-      title.content = title.content.replace(syntax, '').trim();
+    for (let [i, token] of tokens.entries()) {
+      if (token.type === 'heading_open') {
+        const heading = tokens[i + 1];
+        // When heading level is greater than `<h1>`, in order to find the last
+        // text token we need to offset the anchor symbol.
+        const offset = token.tag === 'h1' ? 1 : 5;
+        const title = heading.children[heading.children.length - offset];
+        title.content = title.content.replace(syntax, '');
+      }
     }
   });
-}, /~~(.+)$/);
+}, /\s+~~(.+)$/);
 
 md.use(mdItCodeBlock);
 

--- a/src/markdown/index.js
+++ b/src/markdown/index.js
@@ -9,10 +9,31 @@ export const md = new MarkdownIt({
   typographer: true
 });
 
+const slugifyLegacy = mdItAnchor.defaults.slugify;
+const slugifySpecified = string => {
+  const tail = string.match(/~~(.+)$/);
+  if (tail) {
+    return slugifyLegacy(tail[1]);
+  } else {
+    return slugifyLegacy(string);
+  }
+};
+
 md.use(mdItAnchor, {
   level: 2,
+  slugify: slugifySpecified,
   permalink: true
 });
+
+md.use((md, syntax) => md.core.ruler.push('heading_comments', state => {
+  const tokens = state.tokens;
+  tokens
+    .filter(token => token.type === 'heading_open')
+    .forEach(token => {
+      const title = tokens[tokens.indexOf(token) + 1].children[0];
+      title.content = title.content.replace(syntax, '').trim();
+    });
+}), /~~(.+)$/);
 
 md.use(mdItCodeBlock);
 


### PR DESCRIPTION
By default, anchor is not suitable for multilanguage in most situation, not only because the encoding is hard to "slugify", but also the "compatibility" between itself and "the standard upstream" 's URL. So when the website comes to be multilingual, it needs a way to _fix_ the content of headings that it was (in English).

For example,

``` markdown
# Title

This is a file written in Markdown.

## The syntax

The new syntax I am using is `~~ anchor title`.
```

We are using `markdown-it-anchor` now right? So that we get two anchor: `#title` and `#the-syntax`.

After we translate it into, let's say, `zh-CN`:

``` markdown
# 标题

这是一份用 Markdown 书写的文件。

## 语法

我使用的新语法是 `~~ 用于锚的标题`。
```

These the anchors turn to `#` (nothing)，and it break down the links in other page.

Using the _specified-anchor syntax_,  we can write translations in this way:

``` markdown
# 标题 ~~ Title

这是一份用 Markdown 书写的文件。

## 语法 ~~ The syntax

我使用的新语法是 `~~ 用于锚的标题`。
```

The _visible_ result is equivalent to the former one.  The difference is there are the same anchors in the original one.
