### PR TITLE
Fix CI to allow delivering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ node_js:
 # Use faster Docker architecture on Travis.
 sudo: false
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"
+
 install:
   - yarn
   - node get-langs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "node"
+  - "lts/*"
 
 # Use faster Docker architecture on Travis.
 sudo: false

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "resolve": "^1.1.7"
   },
   "devDependencies": {
-    "eslint-config-xo-react": "^0.16.0",
+    "eslint-config-xo-react": "0.14.0",
     "eslint-plugin-react": "^7.0.0",
     "gethub": "^2.0.2",
     "jstransformer-babel": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,9 +1896,9 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-xo-react@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-xo-react/-/eslint-config-xo-react-0.13.0.tgz#63518dbd8a87f0700f0861fbb6ac0fb5efdf6039"
+eslint-config-xo-react@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-xo-react/-/eslint-config-xo-react-0.14.0.tgz#eaa3ecc14d3860b495f64dfc19a8674d21a93d40"
 
 eslint-config-xo@^0.18.0:
   version "0.18.2"
@@ -4180,9 +4180,17 @@ pug-filters@^2.1.5:
     resolve "^1.1.6"
     uglify-js "^2.6.1"
 
-pug-lexer@^3.0.0, pug-lexer@^3.1.0:
+pug-lexer@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/pug-lexer/-/pug-lexer-3.1.0.tgz#fd087376d4a675b4f59f8fef422883434e9581a2"
+  dependencies:
+    character-parser "^2.1.1"
+    is-expression "^3.0.0"
+    pug-error "^1.3.2"
+
+pug-lexer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pug-lexer/-/pug-lexer-4.0.0.tgz#210c18457ef2e1760242740c5e647bd794cec278"
   dependencies:
     character-parser "^2.1.1"
     is-expression "^3.0.0"


### PR DESCRIPTION
I fixed linter and debug the build on CI.

The problem was in the `node-sass` package which comes within `jstransformer-scss`. It had a problem with building on node@10 (related issue: https://github.com/sass/node-sass/issues/2345).

Instead of waiting for other packages, I just downgrade Node version to LTS one. Now it works well.