### PR TITLE
Improved visibility of sponsor icons

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -89,12 +89,24 @@ $transition: 0.3s ease-in-out;
     }
   }
 }
-
+.nav-link.sponsors {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+  flex-wrap: wrap;
+}
 .sponsor {
-  margin-left: 16px;
-  margin-top: 16px;
+  width: 64px;
   display: block;
   color: hsl(0, 0%, 51%);
+}
+.sponsor:nth-child(1) {
+  width: 100%;
+  padding-left: 16px;
+}
+.sponsor img {
+    position: relative;
+    left: -64px;
 }
 .advert {
   margin-left: 16px;

--- a/templates/_menu.pug
+++ b/templates/_menu.pug
@@ -54,7 +54,7 @@ mixin menu
       +menuItem('support/community')
       +menuItem('support/enterprise')
 
-    .nav-link Sponsors
+    .nav-link.sponsors Sponsors
       a.sponsor(href="https://www.coinnewsspan.com/")
         | coin news
       - for (var i = 0; i < 5; i++)


### PR DESCRIPTION
I thought that maybe by using a little flex wrap the project sponsors could be seen a little better.

**Before:**
![image](https://github.com/user-attachments/assets/e27cde09-deb0-4d78-a164-bd9ca524f41a)

**After:**
![image](https://github.com/user-attachments/assets/2f602f1d-8880-4d15-b85e-20421c3c51df)



